### PR TITLE
Script to scrape a pendle markets spot price history

### DIFF
--- a/contracts/vendor/IPRouterStatic.json
+++ b/contracts/vendor/IPRouterStatic.json
@@ -1,0 +1,2296 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "IPRouterStatic",
+  "sourceName": "contracts/interfaces/IPRouterStatic.sol",
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyDesired",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPtDesired",
+          "type": "uint256"
+        }
+      ],
+      "name": "addLiquidityDualSyAndPtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netLpOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyUsed",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPtUsed",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netTokenDesired",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPtDesired",
+          "type": "uint256"
+        }
+      ],
+      "name": "addLiquidityDualTokenAndPtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netLpOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netTokenUsed",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPtUsed",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyUsed",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyDesired",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPtIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "addLiquiditySinglePtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netLpOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPtToSwap",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFromSwap",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "addLiquiditySingleSyKeepYtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netLpOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netYtOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyToPY",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "addLiquiditySingleSyStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netLpOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPtFromSwap",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyToSwap",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netTokenIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "addLiquiditySingleTokenKeepYtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netLpOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netYtOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyMinted",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyToPY",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netTokenIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "addLiquiditySingleTokenStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netLpOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPtFromSwap",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyMinted",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyToSwap",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "int256",
+          "name": "netPtOut",
+          "type": "int256"
+        }
+      ],
+      "name": "calcPriceImpactPY",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "int256",
+          "name": "netPtOut",
+          "type": "int256"
+        }
+      ],
+      "name": "calcPriceImpactPt",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "int256",
+          "name": "netPtOut",
+          "type": "int256"
+        }
+      ],
+      "name": "calcPriceImpactYt",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "claimOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes4",
+          "name": "selector",
+          "type": "bytes4"
+        }
+      ],
+      "name": "facetAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "SY",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyOut",
+          "type": "uint256"
+        }
+      ],
+      "name": "getAmountTokenToMintSy",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netTokenIn",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getDefaultApproxParams",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "guessMin",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "guessMax",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "guessOffchain",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxIteration",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "eps",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct ApproxParams",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        }
+      ],
+      "name": "getLpToAssetRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        }
+      ],
+      "name": "getLpToSyRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        }
+      ],
+      "name": "getMarketState",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "pt",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "yt",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "sy",
+          "type": "address"
+        },
+        {
+          "internalType": "int256",
+          "name": "impliedYield",
+          "type": "int256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "marketExchangeRateExcludeFee",
+          "type": "uint256"
+        },
+        {
+          "components": [
+            {
+              "internalType": "int256",
+              "name": "totalPt",
+              "type": "int256"
+            },
+            {
+              "internalType": "int256",
+              "name": "totalSy",
+              "type": "int256"
+            },
+            {
+              "internalType": "int256",
+              "name": "totalLp",
+              "type": "int256"
+            },
+            {
+              "internalType": "address",
+              "name": "treasury",
+              "type": "address"
+            },
+            {
+              "internalType": "int256",
+              "name": "scalarRoot",
+              "type": "int256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "expiry",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lnFeeRateRoot",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "reserveFeePercent",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lastLnImpliedRate",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MarketState",
+          "name": "state",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getOwnerAndPendingOwner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "_owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_pendingOwner",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "py",
+          "type": "address"
+        }
+      ],
+      "name": "getPY",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "pt",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "yt",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        }
+      ],
+      "name": "getPtToAssetRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        }
+      ],
+      "name": "getPtToSyRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "getTokensInOut",
+      "outputs": [
+        {
+          "internalType": "address[]",
+          "name": "tokensIn",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "tokensOut",
+          "type": "address[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "components": [
+            {
+              "internalType": "int256",
+              "name": "totalPt",
+              "type": "int256"
+            },
+            {
+              "internalType": "int256",
+              "name": "totalSy",
+              "type": "int256"
+            },
+            {
+              "internalType": "int256",
+              "name": "totalLp",
+              "type": "int256"
+            },
+            {
+              "internalType": "address",
+              "name": "treasury",
+              "type": "address"
+            },
+            {
+              "internalType": "int256",
+              "name": "scalarRoot",
+              "type": "int256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "expiry",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lnFeeRateRoot",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "reserveFeePercent",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lastLnImpliedRate",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MarketState",
+          "name": "state",
+          "type": "tuple"
+        }
+      ],
+      "name": "getTradeExchangeRateExcludeFee",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "int256",
+          "name": "netPtOut",
+          "type": "int256"
+        }
+      ],
+      "name": "getTradeExchangeRateIncludeFee",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        }
+      ],
+      "name": "getUserMarketInfo",
+      "outputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "token",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "amount",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IPActionInfoStatic.TokenAmount",
+              "name": "lpBalance",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "token",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "amount",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IPActionInfoStatic.TokenAmount",
+              "name": "ptBalance",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "token",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "amount",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IPActionInfoStatic.TokenAmount",
+              "name": "syBalance",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "token",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "amount",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IPActionInfoStatic.TokenAmount[]",
+              "name": "unclaimedRewards",
+              "type": "tuple[]"
+            }
+          ],
+          "internalType": "struct IPActionInfoStatic.UserMarketInfo",
+          "name": "res",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "py",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        }
+      ],
+      "name": "getUserPYInfo",
+      "outputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "token",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "amount",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IPActionInfoStatic.TokenAmount",
+              "name": "ptBalance",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "token",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "amount",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IPActionInfoStatic.TokenAmount",
+              "name": "ytBalance",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "token",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "amount",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IPActionInfoStatic.TokenAmount",
+              "name": "unclaimedInterest",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "token",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "amount",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IPActionInfoStatic.TokenAmount[]",
+              "name": "unclaimedRewards",
+              "type": "tuple[]"
+            }
+          ],
+          "internalType": "struct IPActionInfoStatic.UserPYInfo",
+          "name": "res",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sy",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        }
+      ],
+      "name": "getUserSYInfo",
+      "outputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "token",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "amount",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IPActionInfoStatic.TokenAmount",
+              "name": "syBalance",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "token",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "amount",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IPActionInfoStatic.TokenAmount[]",
+              "name": "unclaimedRewards",
+              "type": "tuple[]"
+            }
+          ],
+          "internalType": "struct IPActionInfoStatic.UserSYInfo",
+          "name": "res",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "internalType": "uint128",
+          "name": "additionalAmountToLock",
+          "type": "uint128"
+        },
+        {
+          "internalType": "uint128",
+          "name": "newExpiry",
+          "type": "uint128"
+        }
+      ],
+      "name": "increaseLockPositionStatic",
+      "outputs": [
+        {
+          "internalType": "uint128",
+          "name": "newVeBalance",
+          "type": "uint128"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "YT",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyToMint",
+          "type": "uint256"
+        }
+      ],
+      "name": "mintPyFromSyStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netPYOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "YT",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netTokenIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "mintPyFromTokenStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netPyOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "SY",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netTokenIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "mintSyFromTokenStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netSyOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        }
+      ],
+      "name": "pyIndexCurrentViewMarket",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "yt",
+          "type": "address"
+        }
+      ],
+      "name": "pyIndexCurrentViewYt",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "YT",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPYToRedeem",
+          "type": "uint256"
+        }
+      ],
+      "name": "redeemPyToSyStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netSyOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "YT",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPYToRedeem",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenOut",
+          "type": "address"
+        }
+      ],
+      "name": "redeemPyToTokenStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netTokenOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "SY",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "redeemSyToTokenStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netTokenOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netLpToRemove",
+          "type": "uint256"
+        }
+      ],
+      "name": "removeLiquidityDualSyAndPtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netSyOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPtOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netLpToRemove",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenOut",
+          "type": "address"
+        }
+      ],
+      "name": "removeLiquidityDualTokenAndPtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netTokenOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPtOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyToRedeem",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netLpToRemove",
+          "type": "uint256"
+        }
+      ],
+      "name": "removeLiquiditySinglePtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netPtOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPtFromSwap",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFromBurn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPtFromBurn",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netLpToRemove",
+          "type": "uint256"
+        }
+      ],
+      "name": "removeLiquiditySingleSyStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netSyOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFromBurn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPtFromBurn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFromSwap",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netLpToRemove",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenOut",
+          "type": "address"
+        }
+      ],
+      "name": "removeLiquiditySingleTokenStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netTokenOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFromBurn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPtFromBurn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFromSwap",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "guessMin",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "guessMax",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "guessOffchain",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxIteration",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "eps",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct ApproxParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "setDefaultApproxParams",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "facet",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes4[]",
+              "name": "selectors",
+              "type": "bytes4[]"
+            }
+          ],
+          "internalType": "struct IPMiniDiamond.SelectorsToFacet[]",
+          "name": "arr",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "setFacetForSelectors",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactPtIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactPtForSyStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netSyOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactPtIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenOut",
+          "type": "address"
+        }
+      ],
+      "name": "swapExactPtForTokenStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netTokenOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyToRedeem",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactPtIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactPtForYtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netYtOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "totalPtToSwap",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactSyIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactSyForPtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netPtOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactSyIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactSyForYtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netYtOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountTokenIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactTokenForPtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netPtOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyMinted",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountTokenIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactTokenForYtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netYtOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyMinted",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactYtIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactYtForPtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netPtOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "totalPtSwapped",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactYtIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactYtForSyStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netSyOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyOwedInt",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPYToRepaySyOwedInt",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPYToRedeemSyOutInt",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactYtIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenOut",
+          "type": "address"
+        }
+      ],
+      "name": "swapExactYtForTokenStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netTokenOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyOwedInt",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPYToRepaySyOwedInt",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netPYToRedeemSyOutInt",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactSyOut",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapPtForExactSyStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netPtIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactPtOut",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapSyForExactPtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netSyIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactYtOut",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapSyForExactYtStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netSyIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyReceivedInt",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "totalSyNeedInt",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "market",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactSyOut",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapYtForExactSyStatic",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "netYtIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "netSyFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "priceImpact",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exchangeRateAfter",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        },
+        {
+          "internalType": "bool",
+          "name": "direct",
+          "type": "bool"
+        },
+        {
+          "internalType": "bool",
+          "name": "renounce",
+          "type": "bool"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x",
+  "deployedBytecode": "0x",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/scripts/pendle_twap_scrape.py
+++ b/scripts/pendle_twap_scrape.py
@@ -1,0 +1,28 @@
+import requests, json, os, sys
+from web3 import Web3
+
+
+MARKET=sys.argv[1]
+PENDLE_ORACLE="0x66a1096C6366b2529274dF4f5D8247827fe4CEA8"
+PENDLE_ROUTER_STATIC="0x263833d47eA3fA4a30f269323aba6a107f9eB14C"
+
+if "__main__" in __name__:
+    w3 = Web3(Web3.HTTPProvider('https://eth-mainnet.g.alchemy.com/v2/' + os.getenv("WEB3_ALCHEMY_API_KEY")))
+    assert w3.is_connected() == True, "web3 must be connected"
+
+    blocks = []
+    for log in w3.eth.get_logs({"address": MARKET, 'fromBlock': 0, 'toBlock': "latest"}):
+        if log.blockNumber not in blocks:
+            if log.blockNumber > 17449767:
+                # ^ this is block number from when router static got getPtToAssetRate function
+                blocks += [log.blockNumber]
+    blocks.sort()
+    with open("contracts/vendor/IPRouterStatic.json") as f:
+        abi = json.load(f)["abi"]
+    st = w3.eth.contract(abi=abi, address=PENDLE_ROUTER_STATIC)
+    print("block_number, block_timestamp, spotpt2asset")
+    for blk in blocks:
+        price = (st.functions.getPtToAssetRate(MARKET).call(block_identifier=blk) * 1.0) / 10**18
+        block = w3.eth.get_block(blk)
+        print("%d, %d, %.18f" %( blk, block.timestamp, price))
+    


### PR DESCRIPTION
usage
```bash
export WEB3_ALCHEMY_API_KEY=YOUR_ALCHEMY_KEY
python scripts/pendle_twap_scrape.py PENDLE_MARKET_ADDRESS
```

Generates a CSV containing spot (not TWAP) AMM price for the given market, hardcoded for ETH mainnet.