### PR TITLE
Add pragma evm-version cancun to all vyper files

### DIFF
--- a/contracts/AdapterVault.vy
+++ b/contracts/AdapterVault.vy
@@ -1,5 +1,6 @@
 #pragma version 0.3.10
 #pragma optimize codesize
+#pragma evm-version cancun
 """
 @title Adapter.FI Multi-Vault
 @license Copyright 2023, 2024 Biggest Lab Co Ltd, Benjamin Scherrey, Sajal Kayan, and Eike Caldeweyher

--- a/contracts/FundsAllocator.vy
+++ b/contracts/FundsAllocator.vy
@@ -1,4 +1,5 @@
 #pragma version 0.3.10
+#pragma evm-version cancun
 """
 @title Adapter Fund Allocation Logic
 @license Copyright 2023, 2024 Biggest Lab Co Ltd, Benjamin Scherrey, Sajal Kayan, and Eike Caldeweyher

--- a/contracts/Governance.vy
+++ b/contracts/Governance.vy
@@ -1,4 +1,5 @@
 #pragma version 0.3.10
+#pragma evm-version cancun
 
 """
 

--- a/contracts/adapters/IAdapter.vy
+++ b/contracts/adapters/IAdapter.vy
@@ -1,4 +1,5 @@
 #pragma version 0.3.10
+#pragma evm-version cancun
 """
 @title AdapterVault Adapter interface
 @license Copyright 2023, 2024 Biggest Lab Co Ltd, Benjamin Scherrey, Sajal Kayan, and Eike Caldeweyher

--- a/contracts/adapters/MockLPAdapter.vy
+++ b/contracts/adapters/MockLPAdapter.vy
@@ -1,4 +1,5 @@
 #pragma version 0.3.10
+#pragma evm-version cancun
 
 from vyper.interfaces import ERC20
 # import IAdapter as IAdapter

--- a/contracts/adapters/PendleAdapter.vy
+++ b/contracts/adapters/PendleAdapter.vy
@@ -1,4 +1,5 @@
 #pragma version 0.3.10
+#pragma evm-version cancun
 """
 @title AdapterVault Pendle Adapter
 @license Copyright 2023, 2024 Biggest Lab Co Ltd, Benjamin Scherrey, Sajal Kayan, and Eike Caldeweyher

--- a/contracts/test_helpers/BrokeBalancePool.vy
+++ b/contracts/test_helpers/BrokeBalancePool.vy
@@ -1,4 +1,5 @@
 #pragma version 0.3.10
+#pragma evm-version cancun
 
 MAX_ADAPTERS : constant(int128) = 6
 

--- a/contracts/test_helpers/ERC20.vy
+++ b/contracts/test_helpers/ERC20.vy
@@ -1,4 +1,5 @@
 #pragma version 0.3.10
+#pragma evm-version cancun
 
 # @dev Implementation of ERC-20 token standard.
 # @author Takayuki Jimba (@yudetamago)

--- a/contracts/test_helpers/Fake4626.vy
+++ b/contracts/test_helpers/Fake4626.vy
@@ -1,4 +1,5 @@
 #pragma version 0.3.10
+#pragma evm-version cancun
 
 # @dev Implementation of ERC-20 token standard.
 # @author Takayuki Jimba (@yudetamago)

--- a/contracts/test_helpers/Vault_test.vy
+++ b/contracts/test_helpers/Vault_test.vy
@@ -1,4 +1,5 @@
 #pragma version 0.3.10
+#pragma evm-version cancun
 
 event PoolRebalance:
     newStrategy: Strategy


### PR DESCRIPTION
Adding `#pragma evm-version cancun` to all .vy files. Ape is already configured to target cancun, but with the correct pragma this setting is toolchain agnostic, and would be used when testing with boa.